### PR TITLE
Add hotkey 'U' to quick copy annotations from previous image

### DIFF
--- a/annotation_widgets/image/labeling/logic.py
+++ b/annotation_widgets/image/labeling/logic.py
@@ -426,8 +426,26 @@ class ImageLabelingLogic(AbstractImageAnnotationLogic):
         self.controller.paste()
         self.item_changed = True
 
+    def copy_from_previous_image(self):
+        if self.editing_blocked: return
+        if self.item_id == 0: return
+
+        prev_img_name = self.img_names[self.item_id - 1]
+        prev_labeled_image = LabeledImage.get(name=prev_img_name)
+
+        prev_figures = []
+        if self.project_data.stage is AnnotationStage.REVIEW:
+            prev_figures = [fig.copy() for fig in prev_labeled_image.review_labels]
+        else:
+            all_figs = prev_labeled_image.bboxes + prev_labeled_image.kgroups + prev_labeled_image.masks
+            prev_figures = [fig.copy() for fig in all_figs]
+
+        self.controller.figures = prev_figures
+        self.controller.take_snapshot()
+        self.item_changed = True
+
     def handle_key(self, key: str):
-        if key.isdigit(): 
+        if key.isdigit():
             self.change_label(key)
         elif key.lower() == "d":
             self.delete_command()
@@ -444,4 +462,6 @@ class ImageLabelingLogic(AbstractImageAnnotationLogic):
         elif key.lower() == "s":
             self.make_image_worse = not self.make_image_worse
         elif key.lower() == "g":
-            self.remove_all_objects() 
+            self.remove_all_objects()
+        elif key.lower() == "u":
+            self.copy_from_previous_image() 

--- a/templates/hotkeys.html
+++ b/templates/hotkeys.html
@@ -92,7 +92,7 @@
   </tr>
    <tr>
     <td>U</td>
-    <td style="font-size: 16px;">Copy and paste all figures from previous image</td>
+    <td style="font-size: 16px;">Overwrite figures from previous image to the current image</td>
   </tr>
   <tr>
     <td>Ctrl+Z</td>

--- a/templates/hotkeys.html
+++ b/templates/hotkeys.html
@@ -92,7 +92,7 @@
   </tr>
    <tr>
     <td>U</td>
-    <td style="font-size: 16px;">Overwrite figures from previous image to the current image</td>
+    <td style="font-size: 16px;">Replace the figures in the current image with the figures from the previous image</td>
   </tr>
   <tr>
     <td>Ctrl+Z</td>

--- a/templates/hotkeys.html
+++ b/templates/hotkeys.html
@@ -90,6 +90,10 @@
     <td>Ctrl+V</td>
     <td style="font-size: 16px;">Paste copied figure</td>
   </tr>
+   <tr>
+    <td>U</td>
+    <td style="font-size: 16px;">Copy and paste all figures from previous image</td>
+  </tr>
   <tr>
     <td>Ctrl+Z</td>
     <td style="font-size: 16px;">Undo</td>

--- a/templates/how.html
+++ b/templates/how.html
@@ -73,7 +73,7 @@
         Place cursor under the figure and press <strong>Ctrl+C</strong> to copy it. Use <strong>Ctrl+V</strong> to paste it on another image. If you press <strong>Ctrl+C</strong> when any figure under cursor - it will copy all figures on the image.
         </p>
         <p>
-        Press <strong>U</strong> to overwrite all annotations from the previous image to the current image.
+        Press <strong>U</strong> to replace the figures in the current image with the figures from the previous image.
         </p>
         <p>
         Press <strong>T</strong> if you want to tag image as a trash. After that the <strong>Trash</strong> section on the status bar become red. Press <strong>T</strong> again to remove trash tag from the image.

--- a/templates/how.html
+++ b/templates/how.html
@@ -73,6 +73,9 @@
         Place cursor under the figure and press <strong>Ctrl+C</strong> to copy it. Use <strong>Ctrl+V</strong> to paste it on another image. If you press <strong>Ctrl+C</strong> when any figure under cursor - it will copy all figures on the image.
         </p>
         <p>
+        Press <strong>U</strong> to <strong>quickly</strong> copy and paste all annotations from the previous image to the current image.
+        </p>
+        <p>
         Press <strong>T</strong> if you want to tag image as a trash. After that the <strong>Trash</strong> section on the status bar become red. Press <strong>T</strong> again to remove trash tag from the image.
         </p>
         <p>

--- a/templates/how.html
+++ b/templates/how.html
@@ -73,7 +73,7 @@
         Place cursor under the figure and press <strong>Ctrl+C</strong> to copy it. Use <strong>Ctrl+V</strong> to paste it on another image. If you press <strong>Ctrl+C</strong> when any figure under cursor - it will copy all figures on the image.
         </p>
         <p>
-        Press <strong>U</strong> to <strong>quickly</strong> copy and paste all annotations from the previous image to the current image.
+        Press <strong>U</strong> to overwrite all annotations from the previous image to the current image.
         </p>
         <p>
         Press <strong>T</strong> if you want to tag image as a trash. After that the <strong>Trash</strong> section on the status bar become red. Press <strong>T</strong> again to remove trash tag from the image.


### PR DESCRIPTION
## Summary
Adds a new hotkey `U` that copies all annotations from the previous image to the current image, replacing current annotations.

## Changes
- Added `copy_from_previous_image()` method in `ImageLabelingLogic` class
- Bound to `U` key in `handle_key()` method
- Updated `hotkeys.html` with new hotkey documentation
- Updated `how.html` with usage instructions

## Behavior
- Copies bboxes, keypoints, and masks in annotation mode
- Copies review labels in review mode
- Does nothing on the first image (no previous image exists)
- Respects editing blocks (won't work when editing is disabled) (E)

## Testing
Tested on annotation projects with multiple images. Confirmed:
- Copies correctly from previous image
- Previous image annotations remain unchanged
- Works in both annotation and review modes